### PR TITLE
:sparkles: feat(vision-bbox): add vision model to get border, adjust to different enviroment

### DIFF
--- a/src/agent-zuoyebang/prompt.py
+++ b/src/agent-zuoyebang/prompt.py
@@ -120,6 +120,9 @@ Return the result in a JSON format similar to the following:
 The format of `questioner_box` and `responder_box` should be <bbox>x1 y1 x2 y2</bbox>,
 if you cannot find the box, return the `"null"`.
 
++ DO let x1 < x2 and y1 < y2, (x1, y1) is the top-left corner and (x2, y2) is the bottom-
+  right corner.
+
 EXAMPLE_RETURN_JSON
 
 ``` json
@@ -128,7 +131,7 @@ EXAMPLE_RETURN_JSON
     "<bbox>100 200 300 300</bbox>",
     "<bbox>200 200 400 600</bbox>"
   ],
-  "responder_box": "<bbox>800 800 200 200</bbox>"
+  "responder_box": "<bbox>100 100 200 200</bbox>"
 }
 ```
 

--- a/src/agent-zuoyebang/prompt.py
+++ b/src/agent-zuoyebang/prompt.py
@@ -96,3 +96,40 @@ are definitely not sure, and 1.0 means that you are definitely sure. This is a
 float value between 0.0 and 1.0.
 
 """
+
+prompt_box_select = r"""
+
+Select the two box in the picture:
++ box1: The picture that questioner uploads, usually its' a reduced-sized picture
+  or screenshot of questions or homework.
++ box2: The button that responder should upload to the platform, it has an upload
+  symbol (it's a plus `+`).
+
+Return the result in a JSON format similar to the following:
+
+``` json
+{
+  "questioner_box": [
+    "...",
+    "..."
+  ],
+  "responder_box": "..."
+}
+```
+
+The format of `questioner_box` and `responder_box` should be <bbox>x1 y1 x2 y2</bbox>,
+if you cannot find the box, return the `"null"`.
+
+EXAMPLE_RETURN_JSON
+
+``` json
+{
+  "questioner_box: [
+    "<bbox>100 200 300 300</bbox>",
+    "<bbox>200 200 400 600</bbox>"
+  ],
+  "responder_box": "<bbox>800 800 200 200</bbox>"
+}
+```
+
+"""

--- a/src/agent-zuoyebang/prompt.py
+++ b/src/agent-zuoyebang/prompt.py
@@ -97,7 +97,7 @@ float value between 0.0 and 1.0.
 
 """
 
-prompt_box_select = r"""
+prompt_bbox_select = r"""
 
 Select the two box in the picture:
 + box1: The picture that questioner uploads, usually its' a reduced-sized picture

--- a/src/agent-zuoyebang/start.py
+++ b/src/agent-zuoyebang/start.py
@@ -18,7 +18,7 @@ class WhichScreen(Enum) :
     TASK_HALL_ANSWERING = 3
     QUESTION = 4
 
-CURRENT_SCREEN = WhichScreen.TASK_HALL_INIT
+CURRENT_SCREEN = WhichScreen.TASK_HALL_WAITING
 
 REPHRASE_CLIENT = Ark(api_key = "")
 ANSWER_CLIENT = OpenAI(api_key = "", base_url = "")
@@ -67,12 +67,18 @@ class Utils :
 
     @staticmethod
     def parse_bbox_to_center(bbox : str) -> tuple[float, float] :
+        x_scale = float(os.getenv("x_scale"))
+        y_scale = float(os.getenv("y_scale"))
+
         xy = map(float, bbox.replace("<bbox>", "").replace("</bbox>", "").split(" "))
-        return ((xy[0] + xy[2]) / 2, (xy[1] + xy[3]) / 2)
+        return (
+            (xy[0] + xy[2]) * x_scale / 2, 
+            (xy[1] + xy[3]) * y_scale / 2
+        )
 
     @staticmethod
     def ocr_result(name : str) -> str :
-        
+
         ocr_text = pytesseract.image_to_string(
             "./tmp/{}".format(name),
             lang = "chi_sim"
@@ -240,9 +246,7 @@ class QuestionActions(PageActions) :
 
 class ModelSolving :
     @staticmethod
-    def get_bbox_center(image : str) -> tuple[list[tuple[float, float], tuple[float, float]]] :
-        x_scale = float(os.getenv("x_scale"))
-        y_scale = float(os.getenv("y_scale"))
+    def get_bbox_center(image : str) -> tuple[list[tuple[float, float]], tuple[float, float]] :
 
         image_base64_content = []
         image_base64_content.append({

--- a/src/agent-zuoyebang/start.py
+++ b/src/agent-zuoyebang/start.py
@@ -66,6 +66,11 @@ class Utils :
         ))
 
     @staticmethod
+    def parse_bbox_to_center(bbox : str) -> tuple[float, float] :
+        xy = map(float, bbox.replace("<bbox>", "").replace("</bbox>", "").split(" "))
+        return ((xy[0] + xy[2]) / 2, (xy[1] + xy[3]) / 2)
+
+    @staticmethod
     def ocr_result(name : str) -> str :
         
         ocr_text = pytesseract.image_to_string(
@@ -111,7 +116,6 @@ class Utils :
                     return
 
         os.remove("./tmp/" + screenshot)
-
 
 class DeviceActions :
     @staticmethod
@@ -180,38 +184,101 @@ class QuestionActions(PageActions) :
 
     @staticmethod
     def open_user_picture() -> None :
-        Utils.click_position("button_user_question_picture", "user question picture")
+        Utils.click_position(
+            "button_user_question_picture",
+            "user question picture"
+        )
 
     @staticmethod
     def close_user_picture() -> None :
-        Utils.click_position("button_user_question_picture", "close user question picture")
+        Utils.click_position(
+            "button_user_question_picture",
+            "close user question picture"
+        )
 
     @staticmethod
     def take_from_gallery() -> None :
-        Utils.click_position("button_take_from_gallery", "take from gallery")
+        Utils.click_position(
+            "button_take_from_gallery",
+            "take from gallery"
+        )
 
     @staticmethod
     def select_first_picture() -> None :
-        Utils.click_position("button_select_first_picture", "select first picture")
+        Utils.click_position(
+            "button_select_first_picture",
+            "select first picture"
+        )
     
     @staticmethod
     def confirm_first_picture() -> None :
-        Utils.click_position("button_confirm_first_picture", "confirm first picture")
+        Utils.click_position(
+            "button_confirm_first_picture",
+            "confirm first picture"
+        )
 
     @staticmethod
     def confirm_upload() -> None :
-        Utils.click_position("button_confirm_upload", "confirm upload")
+        Utils.click_position(
+            "button_confirm_upload",
+            "confirm upload"
+        )
     
     @staticmethod
     def upload_answer() -> None :
-        Utils.click_position("button_upload_answer", "upload answer")
+        Utils.click_position(
+            "button_upload_answer", 
+            "upload answer"
+        )
 
     @staticmethod
     def confirm_answer() -> None :
-        Utils.click_position("button_confirm_answer", "confirm answer")
-
+        Utils.click_position(
+            "button_confirm_answer", 
+            "confirm answer"
+        )
 
 class ModelSolving :
+    @staticmethod
+    def get_bbox_center(image : str) -> tuple[list[tuple[float, float], tuple[float, float]]] :
+        x_scale = float(os.getenv("x_scale"))
+        y_scale = float(os.getenv("y_scale"))
+
+        image_base64_content = []
+        image_base64_content.append({
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64,{}".format(Utils.encode_image(image))
+            }
+        })
+
+        messages = [
+            { "role": "system", "content": prompt.prompt_bbox_select },
+            { "role": "user", "content": image_base64_content }
+        ]
+
+        response_json = REPHRASE_CLIENT.chat.completions.create(
+            model = "doubao-1.5-vision-pro-250328",
+            messages = messages,
+            response_format = {
+                "type": "json_object"
+            },
+            temperature = 0.0,
+            stream = False
+        )
+
+        bbox_json = json.loads(response_json.choices[0].message.content)
+
+        print("🤖 Get border box of question pictures and submit button: {}".format(bbox_json))
+
+        questioner_str : list[str] = bbox_json["questioner_box"]
+        responder_str : str = bbox_json["responder_box"]
+
+        questioners = map(Utils.parse_bbox_to_center, questioner_str)
+        responder = Utils.parse_bbox_to_center(responder_str)
+
+        return (questioners, responder)
+
     @staticmethod
     def get_rephrased_question(names : list[str]) -> str :
         rephrased_certainty_value = float(os.getenv("rephrased_certainty"))
@@ -262,7 +329,6 @@ class ModelSolving :
             else :
                 print("💥 Rephrased question is not correct.")
                 exit()
-
 
     @staticmethod
     def get_ai_answer(rephrased : str) -> tuple[str, str] :
@@ -322,18 +388,33 @@ if __name__ == "__main__" :
             case WhichScreen.QUESTION :
                 overall = QuestionActions.take_user_question()
                 _()
-                QuestionActions.open_user_picture()
+                questioners, responder = ModelSolving.get_bbox_center(overall)
                 _()
-                details = QuestionActions.take_user_question()
-                _()
-                QuestionActions.close_user_picture()
-                _()
-                rephrased = ModelSolving.get_rephrased_question([overall, details])
+
+                details : list[str] = []
+                for questioner in questioners :
+                    os.environ["button_user_question_picture"] = "{},{}".format(
+                        questioner[0],
+                        questioner[1]
+                    )
+                    QuestionActions.open_user_picture()
+                    _()
+                    details.append(QuestionActions.take_user_question())
+                    _()
+                    QuestionActions.close_user_picture()
+                    _()
+
+                rephrased = ModelSolving.get_rephrased_question([overall, *details])
                 answer, analysis = ModelSolving.get_ai_answer(rephrased)
                 html_name = gen.generate_html(answer, analysis)
                 picture_name = gen.html_to_picture(html_name)
                 _()
                 DeviceActions.transfer_answer_picture(picture_name)
+
+                os.environ["button_take_from_gallery"] = "{},{}".format(
+                    responder[0],
+                    responder[1]
+                )
                 QuestionActions.take_from_gallery()
                 _()
                 QuestionActions.select_first_picture()


### PR DESCRIPTION
This PR adds a new prompt to get the border box of user questions and submit button

## Summary by Sourcery

Add vision bbox detection to dynamically locate question and upload button areas and adapt click actions accordingly

New Features:
- Integrate a vision-based model to detect bounding boxes for user question images and the submit/upload button
- Add Utils.parse_bbox_to_center to convert <bbox> annotations into clickable center coordinates
- Automate opening, capturing, and closing of multiple question images based on detected questioner boxes
- Dynamically set the gallery upload button position from vision output for the answer upload flow

Enhancements:
- Refactor click_position calls to multi-line formatting for improved readability

Documentation:
- Introduce prompt_bbox_select in prompt.py to guide the vision model on selecting and formatting bounding boxes